### PR TITLE
Leave a message when line busy

### DIFF
--- a/controllers/controller.rb
+++ b/controllers/controller.rb
@@ -43,6 +43,16 @@ class Controller < Sinatra::Base
     200
   end
 
+  post '/message_recorded' do
+    200
+  end
+
+  post '/last_message_recording_ready' do
+    recording = twilio_client.account.recordings.get(params['RecordingSid'])
+    notifier.last_message_recording_notification(recording: recording)
+    200
+  end
+
   private
 
   def check_line_busy(client:)

--- a/services/create_twilio_conference.rb
+++ b/services/create_twilio_conference.rb
@@ -22,7 +22,10 @@ class CreateTwilioConference
   private
 
   def handle_busy_line(response)
-    response.Say 'Our line is currently busy, please try again later'
+    response.Say 'Our line is currently busy, leave us a message or try again later'
+    response.Record maxLength: 180,
+                    action: '/message_recorded',
+                    recordingStatusCallback: '/last_message_recording_ready'
     response.Hangup
   end
 

--- a/services/slack_notifier.rb
+++ b/services/slack_notifier.rb
@@ -36,6 +36,13 @@ class SlackNotifier
                             text: 'Call finished :end:')
   end
 
+  def last_message_recording_notification(recording:)
+    @recording = recording
+    client.chat_postMessage(channel: slack_channel,
+                            text: 'Last message recording is ready for you!',
+                            attachments: [last_recording_notification].to_json)
+  end
+
   private
 
   def post_incoming_call_message(line_busy: false)
@@ -70,6 +77,16 @@ class SlackNotifier
       'author_name': "Number: #{@from}\n Location: #{@location}",
       'title': 'Click HERE to answer the call',
       'title_link': "#{@web_client_link}?conf_token=#{@conf_token}"
+    }
+  end
+
+  def last_recording_notification
+    {
+      'fallback': 'You can\'t view the message here.',
+      'color': '#36a64f',
+      'author_name': "Number: #{@from}\n Duration: #{@recording.duration}",
+      'title': 'Click HERE to view the recording',
+      'title_link': @recording.mp3
     }
   end
 


### PR DESCRIPTION
Added recording a message when client is calling and the line is busy:
* created routes in controller
* updated CreateTwilioConference service
* extended SlackNotifier with recorded message notifications

We have 2 routes to handle it because it's the Way Twilio works. After recording a message it sends a [request to current URL by default](https://www.twilio.com/docs/api/twiml/record), and we don't want that, so we're just returning 200 in action method. The second one is handling the notification when the last message recorded is ready.